### PR TITLE
Use Name struct directly, instead of String

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-hyper = "0.12.18"
+hyper = "0.12.21"
 futures = "0.1.25"
 tokio-fs = "0.1.4"
 log = "0.4.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,7 @@ struct CacheEntry {
     timestamp: Option<Instant>,
 }
 
-/// Builder for [`CachedResolver`]s.
-///
-/// [`CachedResolver`]: struct.CachedResolver.html
+/// Builder for [`CachedResolver`].
 pub struct CachedResolverBuilder<R: Resolve> {
     resolver: R,
     resolver_timeout: Option<Duration>,
@@ -42,6 +40,8 @@ pub struct CachedResolverBuilder<R: Resolve> {
 }
 
 impl<R: Resolve> CachedResolverBuilder<R> {
+    /// Returns a new builder that will build a [`CachedResolver`] using `resolver` as the
+    /// underlying DNS resolver.
     pub fn new(resolver: R) -> Self {
         Self {
             resolver,
@@ -52,11 +52,15 @@ impl<R: Resolve> CachedResolverBuilder<R> {
         }
     }
 
+    /// Sets a timeout that will be used to time out requests to the underlying resolver.
+    /// By default there is no timeout. So lookups using the underlying resolver will continue
+    /// until they complete or return an error.
     pub fn timeout(mut self, resolver_timeout: Duration) -> Self {
         self.resolver_timeout = Some(resolver_timeout);
         self
     }
 
+    /// Sets an initial fallback cache. This cache will bootstrap the cached resolver.
     pub fn cache(mut self, cache: HashMap<Name, Vec<IpAddr>>) -> Self {
         let mut timestamped_cache = HashMap::with_capacity(cache.len());
         for (name, addrs) in cache {
@@ -72,6 +76,19 @@ impl<R: Resolve> CachedResolverBuilder<R> {
         self
     }
 
+    /// Sets how old the cache for a domain has to be before a lookup of that domain triggers a
+    /// cache update with the underlying resolver, `R`. Not setting this means resolving a name
+    /// already in the cache will always just return the cached value directly.
+    ///
+    /// Note that if setting this at all, all entries given to [`cache`] are considered
+    /// immediately expired and will trigger a lookup on first access.
+    ///
+    /// Even expired cache entries are returned from this resolver if doing a lookup using
+    /// the underlying resolver fails. So "expired" in this context does not mean discarded.
+    /// It just means that trying to access it attempts to update it, in contrast to just
+    /// returning the cached value immediately.
+    ///
+    /// [`cache`]: #method.cache
     pub fn cache_expiry(mut self, expiry: Duration) -> Self {
         self.cache_expiry = Some(expiry);
         self
@@ -82,6 +99,7 @@ impl<R: Resolve> CachedResolverBuilder<R> {
         self
     }
 
+    /// Constructs the [`CachedResolver`] and the corresponding [`ResolverHandle`].
     pub fn build(self) -> (CachedResolver<R>, ResolverHandle) {
         let (handles_tx, handles_rx) = mpsc::channel(0);
         let cached_resolver = CachedResolver {
@@ -247,6 +265,8 @@ impl<R: Resolve> Future for CachedResolver<R> {
 /// A handle to a [`CachedResolver`]. This type implements the hyper `Resolve` trait and can be used
 /// as the resolver on a hyper `HttpConnector`.
 /// Cloning this returns a new handle backed by the same caching [`CachedResolver`].
+///
+/// These handles will only work as long as their backing [`CachedResolver`] is running.
 #[derive(Clone)]
 pub struct ResolverHandle {
     resolver: mpsc::Sender<(Name, oneshot::Sender<IntoIter<IpAddr>>)>,

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -15,9 +15,10 @@ pub enum OptionalTimeout<F: Future> {
 }
 
 impl<F: Future> OptionalTimeout<F> {
-    /// Create a new `OptionalTimeout` future.
+    /// Creates a new `OptionalTimeout` future.
     ///
-    /// The duration parameter may be `None` to indicate there is no time limit.
+    /// The duration parameter may be `None` to indicate there is no time limit. This means that
+    /// `future` will run as normal.
     pub fn new(future: F, timeout: Option<Duration>) -> Self {
         match timeout {
             Some(timeout) => OptionalTimeout::Limited(Timeout::new(future, timeout)),


### PR DESCRIPTION
hyper `0.12.21` has now been released. And contains my patches for the `Name` struct. Allowing construction of it via `FromStr`. Also implements `Hash + Eq` and a lot more. Allows us to use the `Name` struct directly for everything that represents a domain here, instead of converting it to a `String` all the time.

Also added some documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/hyper-dnscache/3)
<!-- Reviewable:end -->
