### PR TITLE
Add file caching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ futures = "0.1.25"
 tokio-fs = "0.1.4"
 log = "0.4.6"
 tokio-timer = "0.2.8"
+serde_json = "1.0"
+err-derive = "0.1.5"
 
 [dev-dependencies]
 tokio = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ err-derive = "0.1.5"
 
 [dev-dependencies]
 tokio = "0.1"
+env_logger = "0.6.0"

--- a/examples/nslookup.rs
+++ b/examples/nslookup.rs
@@ -1,0 +1,57 @@
+use hyper::client::connect::dns::{GaiResolver, Name, Resolve};
+use hyper_dnscache::*;
+use std::{env, str::FromStr};
+
+
+fn main() {
+    env_logger::init();
+    let mut args = env::args().skip(1);
+    let name_str = args.next().expect("Give domain name as first argument");
+    let name = Name::from_str(&name_str).expect("Given domain has an invalid format");
+
+    let cache_file = args.next();
+
+    let resolver = GaiResolver::new(1);
+    let mut cached_resolver_builder = CachedResolver::builder(resolver);
+    if let Some(cache_file) = cache_file {
+        cached_resolver_builder = cached_resolver_builder.cache_file(cache_file);
+    }
+    let (cached_resolver, handle) = unwrap_log(cached_resolver_builder.build());
+
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.spawn(cached_resolver);
+
+    let result = runtime.block_on(handle.resolve(name));
+    match result {
+        Ok(addrs) => {
+            for addr in addrs {
+                println!("{}", addr);
+            }
+        }
+        Err(e) => {
+            eprintln!("Unable to resolve domain: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+fn unwrap_log<T, E: std::error::Error>(result: Result<T, E>) -> T {
+    match result {
+        Ok(t) => t,
+        Err(e) => {
+            log_error(&e);
+            std::process::exit(1);
+        }
+    }
+}
+
+fn log_error(error: &impl std::error::Error) {
+    let mut buffer = format!("Error: {}", error);
+    let mut source: Option<&dyn std::error::Error> = error.source();
+    while let Some(error) = source {
+        buffer.push_str("\nCaused by: ");
+        buffer.push_str(&error.to_string());
+        source = error.source();
+    }
+    log::error!("{}", buffer);
+}

--- a/src/cache_storer.rs
+++ b/src/cache_storer.rs
@@ -28,8 +28,7 @@ impl CacheStorer for JsonStorer {
         let file_cache: HashMap<String, Vec<IpAddr>> = serde_json::from_slice(&cache_data)
             .map_err(|e| Error::DeserializeCacheError(self.0.clone(), e))?;
 
-        // Insert all entries from the cache loaded from disk. May overwrite entries from the
-        // first in-memory cache.
+        // Convert the map so the `String` key becomes a `Name`.
         let mut cache = HashMap::with_capacity(file_cache.len());
         for (name_str, addrs) in file_cache {
             let name = Name::from_str(&name_str)
@@ -51,10 +50,11 @@ impl CacheStorer for JsonStorer {
             self.0.display()
         );
 
-        let mut file_cache = HashMap::with_capacity(cache.len());
-        for (name, addrs) in cache {
-            file_cache.insert(name.to_string(), addrs);
-        }
+        // Convert the map so the `Name` key becomes a `String`.
+        let file_cache: HashMap<String, Vec<IpAddr>> = cache
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect();
 
         let cache_data =
             serde_json::to_vec_pretty(&file_cache).map_err(|e| Error::SerializeCacheError(e))?;

--- a/src/cache_storer.rs
+++ b/src/cache_storer.rs
@@ -1,7 +1,7 @@
 use hyper::client::connect::dns::{InvalidNameError, Name};
 use std::{collections::HashMap, fs, io, net::IpAddr, path::PathBuf, str::FromStr};
 
-pub trait DiskCache {
+pub trait CacheStorer {
     type Error: std::error::Error;
 
     fn load(&mut self) -> Result<HashMap<Name, Vec<IpAddr>>, Self::Error>;
@@ -10,16 +10,16 @@ pub trait DiskCache {
 }
 
 
-/// The default `DiskCache` implementation. Stores the DNS cache serialized as JSON.
-pub struct JsonCacher(PathBuf);
+/// The default `CacheStorer` implementation. Stores the DNS cache serialized as JSON.
+pub struct JsonStorer(PathBuf);
 
-impl JsonCacher {
+impl JsonStorer {
     pub fn new(path: impl Into<PathBuf>) -> Self {
         Self(path.into())
     }
 }
 
-impl DiskCache for JsonCacher {
+impl CacheStorer for JsonStorer {
     type Error = Error;
 
     fn load(&mut self) -> Result<HashMap<Name, Vec<IpAddr>>, Self::Error> {

--- a/src/cache_storer.rs
+++ b/src/cache_storer.rs
@@ -25,8 +25,8 @@ impl CacheStorer for JsonStorer {
     fn load(&mut self) -> Result<HashMap<Name, Vec<IpAddr>>, Self::Error> {
         // Load and deserialize cache file.
         let cache_data = fs::read(&self.0).map_err(|e| Error::ReadFileError(self.0.clone(), e))?;
-        let file_cache: HashMap<String, Vec<IpAddr>> =
-            serde_json::from_slice(&cache_data).map_err(|e| Error::DeserializeCacheError(e))?;
+        let file_cache: HashMap<String, Vec<IpAddr>> = serde_json::from_slice(&cache_data)
+            .map_err(|e| Error::DeserializeCacheError(self.0.clone(), e))?;
 
         // Insert all entries from the cache loaded from disk. May overwrite entries from the
         // first in-memory cache.
@@ -67,8 +67,8 @@ impl CacheStorer for JsonStorer {
 pub enum Error {
     #[error(display = "Failed to read cache file at {:?}", _0)]
     ReadFileError(PathBuf, #[error(cause)] io::Error),
-    #[error(display = "Failed to deserialize cache file content")]
-    DeserializeCacheError(#[error(cause)] serde_json::Error),
+    #[error(display = "Failed to deserialize cache file at {:?}", _0)]
+    DeserializeCacheError(PathBuf, #[error(cause)] serde_json::Error),
     #[error(display = "Cache contained invalid domain name: {}", _0)]
     InvalidDomainNameError(String, #[error(cause)] InvalidNameError),
     #[error(display = "Failed to write cache data to {:?}", _0)]

--- a/src/disk_cacher.rs
+++ b/src/disk_cacher.rs
@@ -1,0 +1,72 @@
+use hyper::client::connect::dns::Name;
+use std::{collections::HashMap, fs, io, net::IpAddr, path::PathBuf, str::FromStr};
+
+pub trait DiskCache {
+    type Error: std::error::Error;
+
+    fn load(&mut self) -> Result<HashMap<Name, Vec<IpAddr>>, Self::Error>;
+
+    fn store(&mut self, cache: HashMap<Name, Vec<IpAddr>>) -> Result<(), Self::Error>;
+}
+
+
+/// The default `DiskCache` implementation. Stores the DNS cache serialized as JSON.
+pub struct JsonCacher(PathBuf);
+
+impl JsonCacher {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self(path.into())
+    }
+}
+
+impl DiskCache for JsonCacher {
+    type Error = CacheError;
+
+    fn load(&mut self) -> Result<HashMap<Name, Vec<IpAddr>>, Self::Error> {
+        // Load and deserialize cache file.
+        let cache_data = fs::read(&self.0).map_err(|e| CacheError::ReadFileError(e))?;
+        let file_cache: HashMap<String, Vec<IpAddr>> = serde_json::from_slice(&cache_data)
+            .map_err(|e| CacheError::DeserializeCacheError(e))?;
+
+        // Insert all entries from the cache loaded from disk. May overwrite entries from the
+        // first in-memory cache.
+        let mut cache = HashMap::with_capacity(file_cache.len());
+        for (name_str, addrs) in file_cache {
+            let name =
+                Name::from_str(&name_str).map_err(|e| CacheError::InvalidDomainNameError(e))?;
+            cache.insert(name, addrs);
+        }
+        log::debug!(
+            "Loaded {} DNS entries from {}",
+            cache.len(),
+            self.0.display()
+        );
+        Ok(cache)
+    }
+
+    fn store(&mut self, cache: HashMap<Name, Vec<IpAddr>>) -> Result<(), Self::Error> {
+        let mut file_cache = HashMap::with_capacity(cache.len());
+        for (name, addrs) in cache {
+            file_cache.insert(name.to_string(), addrs);
+        }
+
+        let cache_data = serde_json::to_vec_pretty(&file_cache)
+            .map_err(|e| CacheError::SerializeCacheError(e))?;
+        fs::write(&self.0, &cache_data).map_err(|e| CacheError::WriteFileError(e))?;
+        unimplemented!();
+    }
+}
+
+#[derive(Debug, err_derive::Error)]
+pub enum CacheError {
+    #[error(display = "Failed to read cache file content")]
+    ReadFileError(#[error(cause)] io::Error),
+    #[error(display = "Failed to deserialize cache file content")]
+    DeserializeCacheError(#[error(cause)] serde_json::Error),
+    #[error(display = "Cache contained invalid domain name")]
+    InvalidDomainNameError(#[error(cause)] hyper::client::connect::dns::InvalidNameError),
+    #[error(display = "Failed to write serialized cache data to file")]
+    WriteFileError(#[error(cause)] io::Error),
+    #[error(display = "Failed to serialize cache")]
+    SerializeCacheError(#[error(cause)] serde_json::Error),
+}

--- a/src/disk_cacher.rs
+++ b/src/disk_cacher.rs
@@ -45,6 +45,12 @@ impl DiskCache for JsonCacher {
     }
 
     fn store(&mut self, cache: HashMap<Name, Vec<IpAddr>>) -> Result<(), Self::Error> {
+        log::debug!(
+            "Writing {} DNS entries to {}",
+            cache.len(),
+            self.0.display()
+        );
+
         let mut file_cache = HashMap::with_capacity(cache.len());
         for (name, addrs) in cache {
             file_cache.insert(name.to_string(), addrs);
@@ -53,7 +59,7 @@ impl DiskCache for JsonCacher {
         let cache_data = serde_json::to_vec_pretty(&file_cache)
             .map_err(|e| CacheError::SerializeCacheError(e))?;
         fs::write(&self.0, &cache_data).map_err(|e| CacheError::WriteFileError(e))?;
-        unimplemented!();
+        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use futures::{
     Async, Future, Poll, Sink, Stream,
 };
 use hyper::client::connect::dns::{Name, Resolve};
+use log::debug;
 use std::{
     collections::HashMap,
     io,
@@ -17,10 +18,14 @@ use std::{
 // * Read cache on creation
 // * Writing cache to disk on each change
 // * Optional filtering of results from underlying resolver
+// * Limit the size of the in-memory cache. Use an LRU cache or similar.
+
+
+pub mod disk_cacher;
+pub use disk_cacher::DiskCache;
 
 mod timeout;
 use self::timeout::OptionalTimeout;
-
 
 struct CacheEntry {
     /// The IPs for this domain.
@@ -31,24 +36,46 @@ struct CacheEntry {
 }
 
 /// Builder for [`CachedResolver`].
-pub struct CachedResolverBuilder<R: Resolve> {
+pub struct CachedResolverBuilder<R: Resolve, C: DiskCache = disk_cacher::JsonCacher> {
     resolver: R,
     resolver_timeout: Option<Duration>,
     cache: Option<HashMap<Name, CacheEntry>>,
     cache_expiry: Option<Duration>,
-    cache_file: Option<PathBuf>,
+    file_cacher: Option<C>,
 }
 
-impl<R: Resolve> CachedResolverBuilder<R> {
+impl<R: Resolve> CachedResolverBuilder<R, disk_cacher::JsonCacher> {
+    /// Sets a file path to load cache from/store cache to. If this is set then the file will be
+    /// read and parsed in [`build`]. Any entries from the file that overlaps with entries given
+    /// to [`cache`] will replace those for the in-memory cache of the resulting
+    /// [`CachedResolver`].
+    ///
+    /// At any point where the in-memory cache is updated thanks to a resolution with the underlying
+    /// resolver, the in-memory cache will be serialized and written to the file at the path given
+    /// here.
+    ///
+    /// This method is just a shorthand for calling [`file_cacher`] with
+    /// `JsonCacher::new(cache_file)`
+    ///
+    /// [`build`]: #method.build
+    /// [`cache`]: #method.cache
+    /// [`file_cacher`]: #method.file_cacher
+    pub fn cache_file(mut self, cache_file: impl Into<PathBuf>) -> Self {
+        self.file_cacher = Some(disk_cacher::JsonCacher::new(cache_file));
+        self
+    }
+}
+
+impl<R: Resolve, C: DiskCache> CachedResolverBuilder<R, C> {
     /// Returns a new builder that will build a [`CachedResolver`] using `resolver` as the
     /// underlying DNS resolver.
-    pub fn new(resolver: R) -> Self {
+    pub fn new(resolver: R, file_cacher: Option<C>) -> Self {
         Self {
             resolver,
             resolver_timeout: None,
             cache: None,
             cache_expiry: None,
-            cache_file: None,
+            file_cacher,
         }
     }
 
@@ -76,6 +103,18 @@ impl<R: Resolve> CachedResolverBuilder<R> {
         self
     }
 
+    /// Changes the [`DiskCache`] implementation instance for this builder. Allows customizing
+    /// how the cache is serialized and persisted.
+    pub fn file_cacher<C2: DiskCache>(self, file_cacher: C2) -> CachedResolverBuilder<R, C2> {
+        CachedResolverBuilder {
+            resolver: self.resolver,
+            resolver_timeout: self.resolver_timeout,
+            cache: self.cache,
+            cache_expiry: self.cache_expiry,
+            file_cacher: Some(file_cacher),
+        }
+    }
+
     /// Sets how old the cache for a domain has to be before a lookup of that domain triggers a
     /// resolution with the underlying resolver, `R`, in order to update the cache.
     /// Not setting this means looking up a name already in the cache will always just return the
@@ -95,36 +134,55 @@ impl<R: Resolve> CachedResolverBuilder<R> {
         self
     }
 
-    pub fn cache_file(mut self, cache_file: impl Into<PathBuf>) -> Self {
-        self.cache_file = Some(cache_file.into());
-        self
-    }
-
     /// Constructs the [`CachedResolver`] and the corresponding [`ResolverHandle`].
-    pub fn build(self) -> (CachedResolver<R>, ResolverHandle) {
+    ///
+    /// Returns an error if [`cache_file`] is set and the active cacher, `C`, fails to load the
+    /// cache.
+    ///
+    /// [`cache_file`]: #method.cache_file
+    pub fn build(mut self) -> Result<(CachedResolver<R, C>, ResolverHandle), C::Error> {
+        // Start out with the provided in-memory cache, or an empty one.
+        let mut cache = self.cache.unwrap_or_default();
+        if let Some(file_cacher) = &mut self.file_cacher {
+            let file_cache = file_cacher.load()?;
+            for (name, addrs) in file_cache {
+                cache.insert(
+                    name,
+                    CacheEntry {
+                        addrs,
+                        timestamp: None,
+                    },
+                );
+            }
+        }
+        debug!(
+            "Building CachedResolver with {} entries in the cache.",
+            cache.len()
+        );
+
         let (handles_tx, handles_rx) = mpsc::channel(0);
         let cached_resolver = CachedResolver {
             resolver: self.resolver,
             resolver_timeout: self.resolver_timeout,
-            cache: self.cache.unwrap_or_default(),
+            cache,
             cache_expiry: self.cache_expiry,
-            _cache_file: self.cache_file,
+            _file_cacher: self.file_cacher,
             handles_rx: handles_rx.fuse(),
             ongoing_resolutions: HashMap::new(),
         };
         let handle = ResolverHandle {
             resolver: handles_tx,
         };
-        (cached_resolver, handle)
+        Ok((cached_resolver, handle))
     }
 }
 
-pub struct CachedResolver<R: Resolve> {
+pub struct CachedResolver<R: Resolve, C: DiskCache = disk_cacher::JsonCacher> {
     resolver: R,
     resolver_timeout: Option<Duration>,
     cache: HashMap<Name, CacheEntry>,
     cache_expiry: Option<Duration>,
-    _cache_file: Option<PathBuf>,
+    _file_cacher: Option<C>,
     handles_rx: Fuse<mpsc::Receiver<(Name, oneshot::Sender<Result<IntoIter<IpAddr>, io::Error>>)>>,
     ongoing_resolutions: HashMap<
         Name,
@@ -135,13 +193,13 @@ pub struct CachedResolver<R: Resolve> {
     >,
 }
 
-impl<R: Resolve> CachedResolver<R> {
-    pub fn builder(resolver: R) -> CachedResolverBuilder<R> {
-        CachedResolverBuilder::new(resolver)
+impl<R: Resolve> CachedResolver<R, disk_cacher::JsonCacher> {
+    pub fn builder(resolver: R) -> CachedResolverBuilder<R, disk_cacher::JsonCacher> {
+        CachedResolverBuilder::new(resolver, None)
     }
 }
 
-impl<R: Resolve> CachedResolver<R> {
+impl<R: Resolve, C: DiskCache> CachedResolver<R, C> {
     fn poll_handles(&mut self) -> Async<()> {
         // Process requests from all handles
         loop {
@@ -251,7 +309,7 @@ impl<R: Resolve> CachedResolver<R> {
     }
 }
 
-impl<R: Resolve> Future for CachedResolver<R> {
+impl<R: Resolve, C: DiskCache> Future for CachedResolver<R, C> {
     type Item = ();
     type Error = ();
 
@@ -334,248 +392,5 @@ impl From<timeout::Error<io::Error>> for ResolveError {
         } else {
             unreachable!("Timer error not one of the expected types");
         }
-    }
-}
-
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use futures::future;
-    use std::{
-        net::{Ipv4Addr, Ipv6Addr},
-        str::FromStr,
-        sync::mpsc,
-        thread,
-        time::Duration,
-    };
-    use tokio::prelude::FutureExt;
-
-    struct MockResolver {
-        cache: HashMap<Name, Vec<IpAddr>>,
-        requests: mpsc::Sender<Name>,
-    }
-
-    impl MockResolver {
-        pub fn new(cache: HashMap<Name, Vec<IpAddr>>) -> (Self, mpsc::Receiver<Name>) {
-            let (tx, rx) = mpsc::channel();
-            let resolver = Self {
-                cache,
-                requests: tx,
-            };
-            (resolver, rx)
-        }
-    }
-
-    impl Resolve for MockResolver {
-        type Addrs = IntoIter<IpAddr>;
-        type Future = future::FutureResult<Self::Addrs, io::Error>;
-        fn resolve(&self, name: Name) -> Self::Future {
-            log::debug!("Mock resolving {}", name);
-            let _ = self.requests.send(name.clone());
-            if let Some(addrs) = self.cache.get(&name) {
-                future::ok(addrs.clone().into_iter())
-            } else {
-                future::err(io::Error::new(io::ErrorKind::Other, "fail"))
-            }
-        }
-    }
-
-    // A test resolver that never replies.
-    struct SlowMockResolver;
-
-    impl Resolve for SlowMockResolver {
-        type Addrs = IntoIter<IpAddr>;
-        type Future = future::Empty<Self::Addrs, io::Error>;
-        fn resolve(&self, name: Name) -> Self::Future {
-            log::debug!("Mock resolving {} (will never reply)", name.as_str());
-            future::empty()
-        }
-    }
-
-    #[test]
-    fn no_cache_failing_resolver() {
-        let (resolver, _) = MockResolver::new(HashMap::new());
-        let (cached_resolver, handle) = CachedResolver::builder(resolver).build();
-
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
-        runtime.spawn(cached_resolver);
-        let result = runtime.block_on(handle.resolve(name("example.com")));
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn with_cache_failing_resolver() {
-        let cache = test_cache(&[
-            ("example.com", &[Ipv4Addr::LOCALHOST.into()]),
-            ("test1.example.com", &[Ipv6Addr::LOCALHOST.into()]),
-            (
-                "website.com",
-                &[Ipv6Addr::UNSPECIFIED.into(), Ipv4Addr::UNSPECIFIED.into()],
-            ),
-        ]);
-
-        let (resolver, _) = MockResolver::new(HashMap::new());
-
-        let (cached_resolver, handle) = CachedResolver::builder(resolver).cache(cache).build();
-
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
-        runtime.spawn(cached_resolver);
-
-        let result = runtime
-            .block_on(handle.resolve(name("example.com")))
-            .unwrap();
-        let expected: &[IpAddr] = &[Ipv4Addr::LOCALHOST.into()];
-        assert_eq!(result.as_slice(), expected);
-
-        let result = runtime
-            .block_on(handle.resolve(name("test1.example.com")))
-            .unwrap();
-        let expected: &[IpAddr] = &[Ipv6Addr::LOCALHOST.into()];
-        assert_eq!(result.as_slice(), expected);
-
-        let result = runtime
-            .block_on(handle.resolve(name("website.com")))
-            .unwrap();
-        let expected: &[IpAddr] = &[Ipv6Addr::UNSPECIFIED.into(), Ipv4Addr::UNSPECIFIED.into()];
-        assert_eq!(result.as_slice(), expected);
-
-        let result = runtime.block_on(handle.resolve(name("not-in-cache.com")));
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn no_cache_working_resolver() {
-        let domains = test_cache(&[("example.com", &[Ipv4Addr::new(10, 9, 8, 7).into()])]);
-
-        let (resolver, _) = MockResolver::new(domains);
-
-        let (cached_resolver, handle) = CachedResolver::builder(resolver).build();
-
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
-        runtime.spawn(cached_resolver);
-
-        let result = runtime
-            .block_on(handle.resolve(name("example.com")))
-            .unwrap();
-        let expected: &[IpAddr] = &[Ipv4Addr::new(10, 9, 8, 7).into()];
-        assert_eq!(result.as_slice(), expected);
-    }
-
-    #[test]
-    fn prefer_cache_over_resolver() {
-        let resolver_domains = test_cache(&[("cached.net", &[Ipv4Addr::new(10, 9, 8, 7).into()])]);
-        let cache = test_cache(&[("cached.net", &[Ipv6Addr::LOCALHOST.into()])]);
-
-        let (resolver, _) = MockResolver::new(resolver_domains);
-        let (cached_resolver, handle) = CachedResolver::builder(resolver).cache(cache).build();
-
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
-        runtime.spawn(cached_resolver);
-
-        let result = runtime
-            .block_on(handle.resolve(name("cached.net")))
-            .unwrap();
-        let expected: &[IpAddr] = &[Ipv6Addr::LOCALHOST.into()];
-        assert_eq!(result.as_slice(), expected);
-    }
-
-    #[test]
-    fn timeout_slow_resolver() {
-        let (cached_resolver, handle) = CachedResolver::builder(SlowMockResolver)
-            .timeout(Duration::from_millis(1000))
-            .build();
-
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
-        runtime.spawn(cached_resolver);
-
-        let time_limited_future = handle
-            .resolve(name("some.domain.org"))
-            .timeout(Duration::from_millis(100));
-
-        runtime.block_on(time_limited_future).unwrap_err();
-    }
-
-    #[test]
-    fn slow_resolver_uses_cache_or_empty_result() {
-        let cache = test_cache(&[("a.cached.domain.it", &[Ipv4Addr::new(7, 6, 5, 4).into()])]);
-
-        let (cached_resolver, handle) = CachedResolver::builder(SlowMockResolver)
-            .timeout(Duration::from_millis(100))
-            .cache(cache)
-            .build();
-
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
-        runtime.spawn(cached_resolver);
-
-        let time_limited_future = handle
-            .resolve(name("a.cached.domain.it"))
-            .timeout(Duration::from_millis(1000));
-
-        let result = runtime.block_on(time_limited_future).unwrap();
-        let expected: &[IpAddr] = &[Ipv4Addr::new(7, 6, 5, 4).into()];
-        assert_eq!(result.as_slice(), expected);
-
-        let time_limited_future = handle
-            .resolve(name("some.not.cached.domain.org"))
-            .timeout(Duration::from_millis(1000));
-
-        let result = runtime.block_on(time_limited_future);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn cache_expiry_causes_resolve() {
-        let cache = test_cache(&[("a.cached.domain.it", &[Ipv4Addr::new(7, 6, 5, 4).into()])]);
-        let resolver_domains =
-            test_cache(&[("a.cached.domain.it", &[Ipv4Addr::new(100, 1, 2, 3).into()])]);
-
-        let (resolver, mock_rx) = MockResolver::new(resolver_domains);
-
-        let (cached_resolver, handle) = CachedResolver::builder(resolver)
-            .cache(cache)
-            .cache_expiry(Duration::from_millis(100))
-            .build();
-
-        let mut runtime = tokio::runtime::Runtime::new().unwrap();
-        runtime.spawn(cached_resolver);
-
-        // Cache should always be treated as expired from the start
-        let result = runtime
-            .block_on(handle.resolve(name("a.cached.domain.it")))
-            .unwrap();
-        let expected: &[IpAddr] = &[Ipv4Addr::new(100, 1, 2, 3).into()];
-        assert_eq!(result.as_slice(), expected);
-        assert_eq!(mock_rx.try_recv(), Ok(name("a.cached.domain.it")));
-        assert!(mock_rx.try_recv().is_err());
-
-        // Now the cache should be valid, and not cause a resolve
-        let result = runtime
-            .block_on(handle.resolve(name("a.cached.domain.it")))
-            .unwrap();
-        assert_eq!(result.as_slice(), expected);
-        assert!(mock_rx.try_recv().is_err());
-
-        thread::sleep(Duration::from_secs(1));
-
-        // Now the cache should have expired again, triggering a resolve
-        let result = runtime
-            .block_on(handle.resolve(name("a.cached.domain.it")))
-            .unwrap();
-        assert_eq!(result.as_slice(), expected);
-        assert_eq!(mock_rx.try_recv(), Ok(name("a.cached.domain.it")));
-        assert!(mock_rx.try_recv().is_err());
-    }
-
-    fn name(name: &str) -> Name {
-        Name::from_str(name).unwrap()
-    }
-
-    fn test_cache(entries: &[(&str, &[IpAddr])]) -> HashMap<Name, Vec<IpAddr>> {
-        let mut cache = HashMap::new();
-        for entry in entries {
-            cache.insert(Name::from_str(entry.0).unwrap(), entry.1.to_vec());
-        }
-        cache
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,8 @@ use std::{
 };
 
 // TODO:
-// * Read cache on creation
-// * Writing cache to disk on each change
-// * Optional filtering of results from underlying resolver
+// * Use proper async filesystem operations inside JsonStorer.
+// * Optional filtering of results from underlying resolver.
 // * Limit the size of the in-memory cache. Use an LRU cache or similar.
 
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,305 @@
+use futures::future;
+use hyper::client::connect::dns::{Name, Resolve};
+use hyper_dnscache::*;
+use std::{
+    collections::HashMap,
+    io,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    str::FromStr,
+    sync::mpsc,
+    thread,
+    time::Duration,
+    vec::IntoIter,
+};
+use tokio::prelude::FutureExt;
+
+
+struct MockResolver {
+    cache: HashMap<Name, Vec<IpAddr>>,
+    requests: mpsc::Sender<Name>,
+}
+
+impl MockResolver {
+    pub fn new(cache: HashMap<Name, Vec<IpAddr>>) -> (Self, mpsc::Receiver<Name>) {
+        let (tx, rx) = mpsc::channel();
+        let resolver = Self {
+            cache,
+            requests: tx,
+        };
+        (resolver, rx)
+    }
+}
+
+impl Resolve for MockResolver {
+    type Addrs = IntoIter<IpAddr>;
+    type Future = future::FutureResult<Self::Addrs, io::Error>;
+    fn resolve(&self, name: Name) -> Self::Future {
+        log::debug!("Mock resolving {}", name);
+        let _ = self.requests.send(name.clone());
+        if let Some(addrs) = self.cache.get(&name) {
+            future::ok(addrs.clone().into_iter())
+        } else {
+            future::err(io::Error::new(io::ErrorKind::Other, "fail"))
+        }
+    }
+}
+
+// A test resolver that never replies.
+struct SlowMockResolver;
+
+impl Resolve for SlowMockResolver {
+    type Addrs = IntoIter<IpAddr>;
+    type Future = future::Empty<Self::Addrs, io::Error>;
+    fn resolve(&self, name: Name) -> Self::Future {
+        log::debug!("Mock resolving {} (will never reply)", name.as_str());
+        future::empty()
+    }
+}
+
+struct MockFileCacher {
+    cache: HashMap<Name, Vec<IpAddr>>,
+    stores: mpsc::Sender<HashMap<Name, Vec<IpAddr>>>,
+}
+
+impl MockFileCacher {
+    pub fn new(cache: HashMap<Name, Vec<IpAddr>>) -> (Self, mpsc::Receiver<HashMap<Name, Vec<IpAddr>>>) {
+        let (tx, rx) = mpsc::channel();
+        let cacher = Self {
+            cache,
+            stores: tx,
+        };
+        (cacher, rx)
+    }
+}
+
+impl DiskCache for MockFileCacher {
+    type Error = io::Error;
+
+    fn load(&mut self) -> Result<HashMap<Name, Vec<IpAddr>>, Self::Error> {
+        Ok(self.cache.clone())
+    }
+
+    fn store(&mut self, cache: HashMap<Name, Vec<IpAddr>>) -> Result<(), Self::Error> {
+        let _ = self.stores.send(cache.clone());
+        self.cache = cache;
+        Ok(())
+    }
+}
+
+
+#[test]
+fn no_cache_failing_resolver() {
+    let (resolver, _) = MockResolver::new(HashMap::new());
+    let (cached_resolver, handle) = CachedResolver::builder(resolver).build().unwrap();
+
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.spawn(cached_resolver);
+    let result = runtime.block_on(handle.resolve(name("example.com")));
+    assert!(result.is_err());
+}
+
+#[test]
+fn with_cache_failing_resolver() {
+    let cache = test_cache(&[
+        ("example.com", &[Ipv4Addr::LOCALHOST.into()]),
+        ("test1.example.com", &[Ipv6Addr::LOCALHOST.into()]),
+        (
+            "website.com",
+            &[Ipv6Addr::UNSPECIFIED.into(), Ipv4Addr::UNSPECIFIED.into()],
+        ),
+    ]);
+
+    let (resolver, _) = MockResolver::new(HashMap::new());
+
+    let (cached_resolver, handle) = CachedResolver::builder(resolver)
+        .cache(cache)
+        .build()
+        .unwrap();
+
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.spawn(cached_resolver);
+
+    let result = runtime
+        .block_on(handle.resolve(name("example.com")))
+        .unwrap();
+    let expected: &[IpAddr] = &[Ipv4Addr::LOCALHOST.into()];
+    assert_eq!(result.as_slice(), expected);
+
+    let result = runtime
+        .block_on(handle.resolve(name("test1.example.com")))
+        .unwrap();
+    let expected: &[IpAddr] = &[Ipv6Addr::LOCALHOST.into()];
+    assert_eq!(result.as_slice(), expected);
+
+    let result = runtime
+        .block_on(handle.resolve(name("website.com")))
+        .unwrap();
+    let expected: &[IpAddr] = &[Ipv6Addr::UNSPECIFIED.into(), Ipv4Addr::UNSPECIFIED.into()];
+    assert_eq!(result.as_slice(), expected);
+
+    let result = runtime.block_on(handle.resolve(name("not-in-cache.com")));
+    assert!(result.is_err());
+}
+
+#[test]
+fn no_cache_working_resolver() {
+    let domains = test_cache(&[("example.com", &[Ipv4Addr::new(10, 9, 8, 7).into()])]);
+
+    let (resolver, _) = MockResolver::new(domains);
+
+    let (cached_resolver, handle) = CachedResolver::builder(resolver).build().unwrap();
+
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.spawn(cached_resolver);
+
+    let result = runtime
+        .block_on(handle.resolve(name("example.com")))
+        .unwrap();
+    let expected: &[IpAddr] = &[Ipv4Addr::new(10, 9, 8, 7).into()];
+    assert_eq!(result.as_slice(), expected);
+}
+
+#[test]
+fn prefer_cache_over_resolver() {
+    let resolver_domains = test_cache(&[("cached.net", &[Ipv4Addr::new(10, 9, 8, 7).into()])]);
+    let cache = test_cache(&[("cached.net", &[Ipv6Addr::LOCALHOST.into()])]);
+
+    let (resolver, _) = MockResolver::new(resolver_domains);
+    let (cached_resolver, handle) = CachedResolver::builder(resolver)
+        .cache(cache)
+        .build()
+        .unwrap();
+
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.spawn(cached_resolver);
+
+    let result = runtime
+        .block_on(handle.resolve(name("cached.net")))
+        .unwrap();
+    let expected: &[IpAddr] = &[Ipv6Addr::LOCALHOST.into()];
+    assert_eq!(result.as_slice(), expected);
+}
+
+#[test]
+fn timeout_slow_resolver() {
+    let (cached_resolver, handle) = CachedResolver::builder(SlowMockResolver)
+        .timeout(Duration::from_millis(1000))
+        .build()
+        .unwrap();
+
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.spawn(cached_resolver);
+
+    let time_limited_future = handle
+        .resolve(name("some.domain.org"))
+        .timeout(Duration::from_millis(100));
+
+    runtime.block_on(time_limited_future).unwrap_err();
+}
+
+#[test]
+fn slow_resolver_uses_cache_or_empty_result() {
+    let cache = test_cache(&[("a.cached.domain.it", &[Ipv4Addr::new(7, 6, 5, 4).into()])]);
+
+    let (cached_resolver, handle) = CachedResolver::builder(SlowMockResolver)
+        .timeout(Duration::from_millis(100))
+        .cache(cache)
+        .build()
+        .unwrap();
+
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.spawn(cached_resolver);
+
+    let time_limited_future = handle
+        .resolve(name("a.cached.domain.it"))
+        .timeout(Duration::from_millis(1000));
+
+    let result = runtime.block_on(time_limited_future).unwrap();
+    let expected: &[IpAddr] = &[Ipv4Addr::new(7, 6, 5, 4).into()];
+    assert_eq!(result.as_slice(), expected);
+
+    let time_limited_future = handle
+        .resolve(name("some.not.cached.domain.org"))
+        .timeout(Duration::from_millis(1000));
+
+    let result = runtime.block_on(time_limited_future);
+    assert!(result.is_err());
+}
+
+#[test]
+fn cache_expiry_causes_resolve() {
+    let cache = test_cache(&[("a.cached.domain.it", &[Ipv4Addr::new(7, 6, 5, 4).into()])]);
+    let resolver_domains =
+        test_cache(&[("a.cached.domain.it", &[Ipv4Addr::new(100, 1, 2, 3).into()])]);
+
+    let (resolver, mock_rx) = MockResolver::new(resolver_domains);
+
+    let (cached_resolver, handle) = CachedResolver::builder(resolver)
+        .cache(cache)
+        .cache_expiry(Duration::from_millis(100))
+        .build()
+        .unwrap();
+
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.spawn(cached_resolver);
+
+    // Cache should always be treated as expired from the start
+    let result = runtime
+        .block_on(handle.resolve(name("a.cached.domain.it")))
+        .unwrap();
+    let expected: &[IpAddr] = &[Ipv4Addr::new(100, 1, 2, 3).into()];
+    assert_eq!(result.as_slice(), expected);
+    assert_eq!(mock_rx.try_recv(), Ok(name("a.cached.domain.it")));
+    assert!(mock_rx.try_recv().is_err());
+
+    // Now the cache should be valid, and not cause a resolve
+    let result = runtime
+        .block_on(handle.resolve(name("a.cached.domain.it")))
+        .unwrap();
+    assert_eq!(result.as_slice(), expected);
+    assert!(mock_rx.try_recv().is_err());
+
+    thread::sleep(Duration::from_secs(1));
+
+    // Now the cache should have expired again, triggering a resolve
+    let result = runtime
+        .block_on(handle.resolve(name("a.cached.domain.it")))
+        .unwrap();
+    assert_eq!(result.as_slice(), expected);
+    assert_eq!(mock_rx.try_recv(), Ok(name("a.cached.domain.it")));
+    assert!(mock_rx.try_recv().is_err());
+}
+
+#[test]
+fn loads_disk_cache() {
+    let (resolver, _mock_rx) = MockResolver::new(HashMap::new());
+    let file_cache = test_cache(&[("a.cached.domain.it", &[Ipv4Addr::new(7, 6, 5, 4).into()])]);
+    let (file_cacher, _) = MockFileCacher::new(file_cache);
+
+    let (cached_resolver, handle) = CachedResolver::builder(resolver)
+        .file_cacher(file_cacher)
+        .build()
+        .unwrap();
+
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.spawn(cached_resolver);
+
+    let result = runtime
+        .block_on(handle.resolve(name("a.cached.domain.it")))
+        .unwrap();
+    let expected: &[IpAddr] = &[Ipv4Addr::new(7, 6, 5, 4).into()];
+    assert_eq!(result.as_slice(), expected);
+}
+
+
+fn name(name: &str) -> Name {
+    Name::from_str(name).unwrap()
+}
+
+fn test_cache(entries: &[(&str, &[IpAddr])]) -> HashMap<Name, Vec<IpAddr>> {
+    let mut cache = HashMap::new();
+    for entry in entries {
+        cache.insert(Name::from_str(entry.0).unwrap(), entry.1.to_vec());
+    }
+    cache
+}


### PR DESCRIPTION
Adding the ability to load and store cache from/to file. For persistence between runs.

The file operations are not yet async. So this could potentially cause bad blocking in the tokio thread. I will work on replacing `fs::write` with something from `tokio-fs`, but this PR was already large enough, so we can start with this I think.

Awesome recommendation on `err-derive`. Works really well IMO.

I also added a small `nslookup` example binary. Can be used to test the implementation in the real world. This crate is supposed to be used with `hyper` and not as a standalone resolver. But it can be tested a bit in this way at least.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/hyper-dnscache/5)
<!-- Reviewable:end -->
