### PR TITLE
Make cache storing async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.4.6"
 tokio-timer = "0.2.8"
 serde_json = "1.0"
 err-derive = "0.1.5"
+tokio-io = "0.1.11"
 
 [dev-dependencies]
 tokio = "0.1"

--- a/src/cache_storer.rs
+++ b/src/cache_storer.rs
@@ -1,12 +1,15 @@
+use futures::{Async, Future, Poll};
 use hyper::client::connect::dns::{InvalidNameError, Name};
 use std::{collections::HashMap, fs, io, net::IpAddr, path::PathBuf, str::FromStr};
 
+
 pub trait CacheStorer {
     type Error: std::error::Error;
+    type StoreFuture: Future<Item = (), Error = Self::Error>;
 
     fn load(&mut self) -> Result<HashMap<Name, Vec<IpAddr>>, Self::Error>;
 
-    fn store(&mut self, cache: HashMap<Name, Vec<IpAddr>>) -> Result<(), Self::Error>;
+    fn store(&mut self, cache: HashMap<Name, Vec<IpAddr>>) -> Self::StoreFuture;
 }
 
 
@@ -21,6 +24,7 @@ impl JsonStorer {
 
 impl CacheStorer for JsonStorer {
     type Error = Error;
+    type StoreFuture = Write;
 
     fn load(&mut self) -> Result<HashMap<Name, Vec<IpAddr>>, Self::Error> {
         // Load and deserialize cache file.
@@ -43,7 +47,7 @@ impl CacheStorer for JsonStorer {
         Ok(cache)
     }
 
-    fn store(&mut self, cache: HashMap<Name, Vec<IpAddr>>) -> Result<(), Self::Error> {
+    fn store(&mut self, cache: HashMap<Name, Vec<IpAddr>>) -> Self::StoreFuture {
         log::debug!(
             "Writing {} DNS entries to {}",
             cache.len(),
@@ -56,10 +60,72 @@ impl CacheStorer for JsonStorer {
             .map(|(key, value)| (key.to_string(), value))
             .collect();
 
-        let cache_data =
-            serde_json::to_vec_pretty(&file_cache).map_err(|e| Error::SerializeCacheError(e))?;
-        fs::write(&self.0, &cache_data).map_err(|e| Error::WriteFileError(self.0.clone(), e))?;
-        Ok(())
+
+        Write::new(&file_cache, self.0.clone())
+    }
+}
+
+/// A `Future` that serializes a cache and writes it to a cache file.
+pub struct Write {
+    path: PathBuf,
+    state: Option<WriteState>,
+}
+
+impl Write {
+    pub fn new(cache: &HashMap<String, Vec<IpAddr>>, path: PathBuf) -> Self {
+        let serialize_result = serde_json::to_vec_pretty(cache);
+        Self {
+            path,
+            state: Some(WriteState::Serialize(serialize_result)),
+        }
+    }
+}
+
+enum WriteState {
+    Serialize(serde_json::Result<Vec<u8>>),
+    CreateFile(tokio_fs::file::CreateFuture<PathBuf>, Vec<u8>),
+    Write(tokio_io::io::WriteAll<tokio_fs::File, Vec<u8>>),
+}
+
+impl Future for Write {
+    type Item = ();
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        use WriteState::*;
+        while let Some(state) = self.state.take() {
+            match state {
+                Serialize(result) => match result {
+                    Ok(data) => {
+                        log::trace!("Write cache 1/3 done: serialize => create file");
+                        let create_file = tokio_fs::File::create(self.path.clone());
+                        self.state = Some(CreateFile(create_file, data));
+                    }
+                    Err(e) => return Err(Error::SerializeCacheError(e)),
+                },
+                CreateFile(mut create_file, data) => match create_file.poll() {
+                    Ok(Async::NotReady) => {
+                        self.state = Some(CreateFile(create_file, data));
+                        return Ok(Async::NotReady);
+                    }
+                    Ok(Async::Ready(file)) => {
+                        log::trace!("Write cache 2/3 done: create file => write data");
+                        let write = tokio_io::io::write_all(file, data);
+                        self.state = Some(Write(write));
+                    }
+                    Err(e) => return Err(Error::WriteFileError(self.path.clone(), e)),
+                },
+                Write(mut write) => match write.poll() {
+                    Ok(Async::NotReady) => {
+                        self.state = Some(Write(write));
+                        return Ok(Async::NotReady);
+                    }
+                    Ok(Async::Ready(..)) => log::trace!("Write cache 3/3 done"),
+                    Err(e) => return Err(Error::WriteFileError(self.path.clone(), e)),
+                },
+            }
+        }
+        Ok(Async::Ready(()))
     }
 }
 


### PR DESCRIPTION
We really don't want sync filesystem operations running in our async futures. That could completely block the entire tokio runtime thread for whoever uses this library. So this PR changes the sync store operation into an async one using `tokio-fs`.

The load operation is still sync. No need to make that one async, since load only happens once, on creation, and creation happens before it's submitted to a tokio runtime anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/hyper-dnscache/6)
<!-- Reviewable:end -->
