### PR TITLE
Log cache load error instead of failing

### DIFF
--- a/examples/nslookup.rs
+++ b/examples/nslookup.rs
@@ -1,5 +1,5 @@
 use hyper::client::connect::dns::{GaiResolver, Name, Resolve};
-use hyper_dnscache::*;
+use hyper_dnscache::CachedResolver;
 use std::{env, str::FromStr};
 
 
@@ -16,7 +16,7 @@ fn main() {
     if let Some(cache_file) = cache_file {
         cached_resolver_builder = cached_resolver_builder.cache_file(cache_file);
     }
-    let (cached_resolver, handle) = unwrap_log(cached_resolver_builder.build());
+    let (cached_resolver, handle) = cached_resolver_builder.build();
 
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.spawn(cached_resolver);
@@ -33,25 +33,4 @@ fn main() {
             std::process::exit(1);
         }
     }
-}
-
-fn unwrap_log<T, E: std::error::Error>(result: Result<T, E>) -> T {
-    match result {
-        Ok(t) => t,
-        Err(e) => {
-            log_error(&e);
-            std::process::exit(1);
-        }
-    }
-}
-
-fn log_error(error: &impl std::error::Error) {
-    let mut buffer = format!("Error: {}", error);
-    let mut source: Option<&dyn std::error::Error> = error.source();
-    while let Some(error) = source {
-        buffer.push_str("\nCaused by: ");
-        buffer.push_str(&error.to_string());
-        source = error.source();
-    }
-    log::error!("{}", buffer);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -94,7 +94,7 @@ struct MockStoreError;
 #[test]
 fn no_cache_failing_resolver() {
     let (resolver, _) = MockResolver::new(HashMap::new());
-    let (cached_resolver, handle) = CachedResolver::builder(resolver).build().unwrap();
+    let (cached_resolver, handle) = CachedResolver::builder(resolver).build();
 
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.spawn(cached_resolver);
@@ -115,10 +115,7 @@ fn with_cache_failing_resolver() {
 
     let (resolver, _) = MockResolver::new(HashMap::new());
 
-    let (cached_resolver, handle) = CachedResolver::builder(resolver)
-        .cache(cache)
-        .build()
-        .unwrap();
+    let (cached_resolver, handle) = CachedResolver::builder(resolver).cache(cache).build();
 
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.spawn(cached_resolver);
@@ -151,7 +148,7 @@ fn no_cache_working_resolver() {
 
     let (resolver, _) = MockResolver::new(domains);
 
-    let (cached_resolver, handle) = CachedResolver::builder(resolver).build().unwrap();
+    let (cached_resolver, handle) = CachedResolver::builder(resolver).build();
 
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.spawn(cached_resolver);
@@ -169,10 +166,7 @@ fn prefer_cache_over_resolver() {
     let cache = test_cache(&[("cached.net", &[Ipv6Addr::LOCALHOST.into()])]);
 
     let (resolver, _) = MockResolver::new(resolver_domains);
-    let (cached_resolver, handle) = CachedResolver::builder(resolver)
-        .cache(cache)
-        .build()
-        .unwrap();
+    let (cached_resolver, handle) = CachedResolver::builder(resolver).cache(cache).build();
 
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.spawn(cached_resolver);
@@ -188,8 +182,7 @@ fn prefer_cache_over_resolver() {
 fn timeout_slow_resolver() {
     let (cached_resolver, handle) = CachedResolver::builder(SlowMockResolver)
         .timeout(Duration::from_millis(1000))
-        .build()
-        .unwrap();
+        .build();
 
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.spawn(cached_resolver);
@@ -208,8 +201,7 @@ fn slow_resolver_uses_cache_or_empty_result() {
     let (cached_resolver, handle) = CachedResolver::builder(SlowMockResolver)
         .timeout(Duration::from_millis(100))
         .cache(cache)
-        .build()
-        .unwrap();
+        .build();
 
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.spawn(cached_resolver);
@@ -241,8 +233,7 @@ fn cache_expiry_causes_resolve() {
     let (cached_resolver, handle) = CachedResolver::builder(resolver)
         .cache(cache)
         .cache_expiry(Duration::from_millis(100))
-        .build()
-        .unwrap();
+        .build();
 
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.spawn(cached_resolver);
@@ -282,8 +273,7 @@ fn loads_disk_cache() {
 
     let (cached_resolver, handle) = CachedResolver::builder(resolver)
         .cache_storer(cache_storer)
-        .build()
-        .unwrap();
+        .build();
 
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.spawn(cached_resolver);
@@ -303,8 +293,7 @@ fn stores_disk_cache() {
 
     let (cached_resolver, handle) = CachedResolver::builder(resolver)
         .cache_storer(cache_storer)
-        .build()
-        .unwrap();
+        .build();
 
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.spawn(cached_resolver);


### PR DESCRIPTION
As discussed. We make the cache load just log errors instead of failing. Thus making the resolver builder infallible. But most importantly, makes it possible to use it without an existing cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/hyper-dnscache/7)
<!-- Reviewable:end -->
